### PR TITLE
Adding configuration for animation: duration, on init

### DIFF
--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.h
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.h
@@ -30,6 +30,8 @@
 @property BOOL shouldHideBadgeAtZero;
 // Badge has a bounce animation when value changes
 @property BOOL shouldAnimateBadge;
+// Badge should be animated the first time it is shown
+@property BOOL shouldAnimateInitialBadge;
 // The duration of the badge bounce animation when changing values
 @property CFTimeInterval animateBadgeDuration;
 

--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.h
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.h
@@ -30,6 +30,8 @@
 @property BOOL shouldHideBadgeAtZero;
 // Badge has a bounce animation when value changes
 @property BOOL shouldAnimateBadge;
+// The duration of the badge bounce animation when changing values
+@property CFTimeInterval animateBadgeDuration;
 
 - (BBBadgeBarButtonItem *)initWithCustomUIButton:(UIButton *)customButton;
 

--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
@@ -41,6 +41,7 @@
     self.badgeOriginY   = -9;
     self.shouldHideBadgeAtZero = YES;
     self.shouldAnimateBadge = YES;
+    self.shouldAnimateInitialBadge = NO;
     self.animateBadgeDuration = 0.2;
     // Avoids badge to be clipped when animating its scale
     self.customView.clipsToBounds = NO;
@@ -145,7 +146,7 @@
         self.badge.textAlignment        = NSTextAlignmentCenter;
 
         [self.customView addSubview:self.badge];
-        [self updateBadgeValueAnimated:NO];
+        [self updateBadgeValueAnimated:self.shouldAnimateInitialBadge];
     } else {
         [self updateBadgeValueAnimated:YES];
     }

--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
@@ -41,6 +41,7 @@
     self.badgeOriginY   = -9;
     self.shouldHideBadgeAtZero = YES;
     self.shouldAnimateBadge = YES;
+    self.animateBadgeDuration = 0.2;
     // Avoids badge to be clipped when animating its scale
     self.customView.clipsToBounds = NO;
 }
@@ -90,7 +91,7 @@
         CABasicAnimation * animation = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
         [animation setFromValue:[NSNumber numberWithFloat:1.5]];
         [animation setToValue:[NSNumber numberWithFloat:1]];
-        [animation setDuration:0.2];
+        [animation setDuration:self.animateBadgeDuration];
         [animation setTimingFunction:[CAMediaTimingFunction functionWithControlPoints:.4 :1.3 :1 :1]];
         [self.badge.layer addAnimation:animation forKey:@"bounceAnimation"];
     }


### PR DESCRIPTION
Adding configuration to allow the integration of the BBBadgeBarButtonItem to set the duration of the animation between badge count changes and to set whether the animation should be ran on the initial creation of the badge indicator (e.g. go from 0 to 1 with an animation)
