### PR TITLE
Adds public accessor for userInteractionEnabled on badgeView

### DIFF
--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.h
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.h
@@ -30,6 +30,8 @@
 @property BOOL shouldHideBadgeAtZero;
 // Badge has a bounce animation when value changes
 @property BOOL shouldAnimateBadge;
+// Public accessor for the badge's view userInteractionEnabled property
+@property (nonatomic, assign, getter=isBadgeUserInteractionEnabled) BOOL badgeUserInteractionEnabled;
 
 - (BBBadgeBarButtonItem *)initWithCustomUIButton:(UIButton *)customButton;
 

--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
@@ -125,6 +125,17 @@
     }];
 }
 
+#pragma mark - Getters
+
+// Returns userInteractionEnabled of badge or false if badge = nil
+- (BOOL)isBadgeUserInteractionEnabled
+{
+    if (self.badge) {
+        return self.badge.isUserInteractionEnabled;
+    }
+    return false;
+}
+
 #pragma mark - Setters
 
 - (void)setBadgeValue:(NSString *)badgeValue
@@ -210,6 +221,13 @@
 
     if (self.badge) {
         [self updateBadgeFrame];
+    }
+}
+
+- (void)setBadgeUserInteractionEnabled:(BOOL)badgeUserInteractionEnabled
+{
+    if (self.badge) {
+        self.badge.userInteractionEnabled = badgeUserInteractionEnabled
     }
 }
 

--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
@@ -227,7 +227,7 @@
 - (void)setBadgeUserInteractionEnabled:(BOOL)badgeUserInteractionEnabled
 {
     if (self.badge) {
-        self.badge.userInteractionEnabled = badgeUserInteractionEnabled
+        self.badge.userInteractionEnabled = badgeUserInteractionEnabled;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Remember that each time you change one of these value, the badge will directly b
 @property BOOL shouldHideBadgeAtZero;
 // Badge has a bounce animation when value changes
 @property BOOL shouldAnimateBadge;
+
+// Public accessor for the badge's view userInteractionEnabled property
+@property (nonatomic, assign, getter=isBadgeUserInteractionEnabled) BOOL badgeUserInteractionEnabled;
 ```
 
 You can also choose to turn off the little bounce animation triggered when changing the badge value or decide if 0 should be display or not.


### PR DESCRIPTION
When in use, I found it was hard to tap on the configured BBBarButtonItem whilst it was showing a badge. Therefore, there's added an property to configure userInteractionEnabled for the badge label. Settings userInteractionEnabled to false will result in a visible view but taps will be redirected to the barButton.
