### PR TITLE
Badge corner radius

### DIFF
--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.h
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.h
@@ -9,6 +9,9 @@
 
 @interface BBBadgeBarButtonItem : UIBarButtonItem
 
+// Constant to define `badgeCornerRadius` as automatic
+extern CGFloat const BadgeCornerRadiusAutomatic;
+
 // Each time you change one of the properties, the badge will refresh with your changes
 
 // Badge value to be display
@@ -21,6 +24,8 @@
 @property (nonatomic) UIFont *badgeFont;
 // Padding value for the badge
 @property (nonatomic) CGFloat badgePadding;
+// Corner radius for the badge. If the value is automatic, it rounds the badge.
+@property (nonatomic) CGFloat badgeCornerRadius;
 // Minimum size badge to small
 @property (nonatomic) CGFloat badgeMinSize;
 // Values for offseting the badge over the BarButtonItem you picked

--- a/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
+++ b/BBBadgeBarButtonItem/BBBadgeBarButtonItem.m
@@ -16,6 +16,7 @@
 
 @implementation BBBadgeBarButtonItem
 
+CGFloat const BadgeCornerRadiusAutomatic = CGFLOAT_MAX;
 
 #pragma mark - Init methods
 
@@ -36,6 +37,7 @@
     self.badgeTextColor = [UIColor whiteColor];
     self.badgeFont      = [UIFont systemFontOfSize:12.0];
     self.badgePadding   = 6;
+    self.badgeCornerRadius = BadgeCornerRadiusAutomatic;
     self.badgeMinSize   = 8;
     self.badgeOriginX   = 7;
     self.badgeOriginY   = -9;
@@ -78,8 +80,13 @@
     // Using const we make sure the badge doesn't get too smal
     minWidth = (minWidth < minHeight) ? minHeight : expectedLabelSize.width;
     self.badge.frame = CGRectMake(self.badgeOriginX, self.badgeOriginY, minWidth + padding, minHeight + padding);
-    self.badge.layer.cornerRadius = (minHeight + padding) / 2;
     self.badge.layer.masksToBounds = YES;
+    
+    if (self.badgeCornerRadius == BadgeCornerRadiusAutomatic) {
+        self.badge.layer.cornerRadius = (minHeight + padding) / 2;
+    } else {
+        self.badge.layer.cornerRadius = self.badgeCornerRadius;
+    }
 }
 
 // Handle the badge changing value
@@ -181,6 +188,14 @@
 {
     _badgePadding = badgePadding;
 
+    if (self.badge) {
+        [self updateBadgeFrame];
+    }
+}
+
+- (void)setBadgeCornerRadius:(CGFloat)badgeCornerRadius {
+    _badgeCornerRadius = badgeCornerRadius;
+    
     if (self.badge) {
         [self updateBadgeFrame];
     }

--- a/Example/BBBadgeBarButtonItem/BBViewController.m
+++ b/Example/BBBadgeBarButtonItem/BBViewController.m
@@ -89,4 +89,15 @@
     sender.selected = !sender.selected;
 }
 
+- (IBAction)changeCornerRadiusPressed:(UIButton *)sender {
+    BBBadgeBarButtonItem *barButton = (BBBadgeBarButtonItem *)self.navigationItem.leftBarButtonItem;
+    if (sender.selected) {
+        barButton.badgeCornerRadius = BadgeCornerRadiusAutomatic;
+    }
+    else {
+        barButton.badgeCornerRadius = 3.0;
+    }
+    sender.selected = !sender.selected;
+}
+
 @end

--- a/Example/BBBadgeBarButtonItem/Base.lproj/Main.storyboard
+++ b/Example/BBBadgeBarButtonItem/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="6Nx-np-Y6o">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15G12a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="6Nx-np-Y6o">
     <dependencies>
-        <deployment defaultVersion="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
-        <!--View Controller - BadgeBarButtonItem-->
+        <!--BadgeBarButtonItem-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
                 <viewController id="vXZ-lx-hvc" customClass="BBViewController" sceneMemberID="viewController">
@@ -17,9 +17,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Badge over BarButtonitem" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Z0a-y1-wjy">
+                                <rect key="frame" x="58" y="180" width="205" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Tk-nk-USN">
-                                <rect key="frame" x="40" y="290" width="241" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="40" y="245" width="241" height="30"/>
                                 <state key="normal" title="Fake adding one element to the list">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -27,16 +32,8 @@
                                     <action selector="addItemToListButtonPressed" destination="vXZ-lx-hvc" eventType="touchUpInside" id="YEh-6z-bq9"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Badge over BarButtonitem" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Z0a-y1-wjy">
-                                <rect key="frame" x="58" y="180" width="205" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4sE-hW-C03">
-                                <rect key="frame" x="91" y="414" width="140" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="91" y="369" width="140" height="30"/>
                                 <state key="normal" title="Change badge color">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -45,13 +42,21 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hHO-Ym-1Nx">
-                                <rect key="frame" x="81" y="351" width="160" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="81" y="306" width="160" height="30"/>
                                 <state key="normal" title="Change badge position">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
                                     <action selector="changePositionButtonPressed:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="ldo-Yw-2EA"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3jZ-SY-GYE">
+                                <rect key="frame" x="63" y="424" width="196" height="30"/>
+                                <state key="normal" title="Change badge corner radius">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="changeCornerRadiusPressed:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="8zp-DN-3JR"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -82,9 +87,4 @@
             <point key="canvasLocation" x="75" y="90"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>


### PR DESCRIPTION
I inserted a property to change the corner radius of the badge.

It includes a constant called `BadgeCornerRadiusAutomatic` that, if you set the corner radius to that constant, the badge will always be round; if not, it uses the value on the property.
